### PR TITLE
don't use version(unittest)

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -13,7 +13,6 @@
     "license": "BSD 3-clause",
     "targetType": "library",
     "sourcePaths": ["source"],
-    "versions": ["unitUnthreaded"],
 
     "configurations": [
 
@@ -33,7 +32,8 @@
             "mainSourceFile": "bin/ut.d",
             "dependencies": {
                 "unit-threaded": "*"
-            }
+            },
+            "versions": ["unitUnthreaded", "Test_InfluxD"]
         },
 
         {
@@ -47,7 +47,8 @@
             "libs-posix": [
                 ":libssl.so.1.0.0",
                 ":libcrypto.so.1.0.0"
-            ]
+            ],
+            "versions": ["unitUnthreaded", "Test_InfluxD"]
         }
     ]
 

--- a/source/influxdb/api.d
+++ b/source/influxdb/api.d
@@ -10,7 +10,7 @@
 
 module influxdb.api;
 
-version(unittest)
+version(Test_InfluxD)
     import unit_threaded;
 else
     struct Values { this(string[]...) { } }
@@ -1225,7 +1225,7 @@ unittest {
     SysTime(DateTime(2017, 2, 1), UTC()).toInfluxDateTime.shouldEqual("'2017-02-01T00:00:00Z'");
 }
 
-version(unittest) {
+version(Test_InfluxD) {
     /**
     Example:
     The two lines must be equivalent under InfluxDB's line protocol


### PR DESCRIPTION
stops those sections being compiled in when used as a dependency, in turn means no implicit unit-threaded dependency