### PR TITLE
Updating dependencies

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,8 +5,8 @@
         "Ilya Yaroshenko"
     ],
     "dependencies": {
-        "vibe-d:http": "~>0.8.0",
-        "asdf": ">=0.1.1 <0.7.0"
+        "vibe-d:http": ">=0.8.0 <0.10.0",
+        "asdf": ">=0.1.1 <0.8.0"
     },
     "description": "InfluxDB wrapper",
     "copyright": "Copyright © 2017, Kaleidic Associates Advisory Limited",

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,22 +1,21 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"asdf": "0.6.2",
+		"asdf": "0.7.2",
 		"botan": "1.12.18",
 		"botan-math": "1.0.3",
-		"diet-ng": "1.7.2",
-		"eventcore": "0.9.7",
+		"diet-ng": "1.7.4",
+		"eventcore": "0.9.11",
 		"libasync": "0.8.6",
-		"libevent": "2.0.2+2.0.16",
 		"memutils": "1.0.4",
-		"mir-algorithm": "3.9.24",
-		"mir-core": "1.1.9",
+		"mir-algorithm": "3.10.12",
+		"mir-core": "1.1.40",
 		"mir-linux-kernel": "1.0.1",
 		"openssl": "1.1.6+1.0.1g",
 		"stdx-allocator": "2.77.5",
-		"taggedalgebraic": "0.11.16",
-		"unit-threaded": "1.0.10",
-		"vibe-core": "1.9.3",
-		"vibe-d": "0.8.6"
+		"taggedalgebraic": "0.11.18",
+		"unit-threaded": "1.0.11",
+		"vibe-core": "1.11.1",
+		"vibe-d": "0.9.2"
 	}
 }

--- a/integration/dub.selections.json
+++ b/integration/dub.selections.json
@@ -1,23 +1,22 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"asdf": "0.6.2",
+		"asdf": "0.7.2",
 		"botan": "1.12.18",
 		"botan-math": "1.0.3",
-		"diet-ng": "1.7.2",
-		"eventcore": "0.9.7",
+		"diet-ng": "1.7.4",
+		"eventcore": "0.9.11",
 		"influx-d": {"path":"../"},
 		"libasync": "0.8.6",
-		"libevent": "2.0.2+2.0.16",
 		"memutils": "1.0.4",
-		"mir-algorithm": "3.9.24",
-		"mir-core": "1.1.9",
+		"mir-algorithm": "3.10.12",
+		"mir-core": "1.1.40",
 		"mir-linux-kernel": "1.0.1",
 		"openssl": "1.1.6+1.0.1g",
 		"stdx-allocator": "2.77.5",
-		"taggedalgebraic": "0.11.16",
-		"unit-threaded": "1.0.10",
-		"vibe-core": "1.9.3",
-		"vibe-d": "0.8.6"
+		"taggedalgebraic": "0.11.18",
+		"unit-threaded": "1.0.11",
+		"vibe-core": "1.11.1",
+		"vibe-d": "0.9.2"
 	}
 }

--- a/mir-integration-example/dub.selections.json
+++ b/mir-integration-example/dub.selections.json
@@ -1,23 +1,22 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"asdf": "0.6.2",
+		"asdf": "0.7.2",
 		"botan": "1.12.18",
 		"botan-math": "1.0.3",
-		"diet-ng": "1.7.2",
-		"eventcore": "0.9.7",
+		"diet-ng": "1.7.4",
+		"eventcore": "0.9.11",
 		"influx-d": {"path":"../"},
 		"libasync": "0.8.6",
-		"libevent": "2.0.2+2.0.16",
 		"memutils": "1.0.4",
-		"mir-algorithm": "3.9.24",
-		"mir-core": "1.1.9",
+		"mir-algorithm": "3.10.12",
+		"mir-core": "1.1.40",
 		"mir-linux-kernel": "1.0.1",
 		"openssl": "1.1.6+1.0.1g",
 		"stdx-allocator": "2.77.5",
-		"taggedalgebraic": "0.11.16",
-		"unit-threaded": "1.0.10",
-		"vibe-core": "1.9.3",
-		"vibe-d": "0.8.6"
+		"taggedalgebraic": "0.11.18",
+		"unit-threaded": "1.0.11",
+		"vibe-core": "1.11.1",
+		"vibe-d": "0.9.2"
 	}
 }

--- a/source/influxdb/api.d
+++ b/source/influxdb/api.d
@@ -1005,11 +1005,11 @@ struct Result {
  */
 struct MeasurementSeries {
 
-    import asdf: serializationIgnoreIn, Asdf;
+    import asdf: serdeIgnoreIn, Asdf;
 
     string name;
     string[] columns;
-    @serializationIgnoreIn string[][] values;
+    @serdeIgnoreIn string[][] values;
 
     static struct Rows {
         import std.range: Transversal, TransverseOptions;


### PR DESCRIPTION
Fixes `Selected package vibe-d 0.9.2 does not match the dependency specification ~>0.8.0 in package influx-d.` when using 0.9.0 or higher of vibe-d.

Fixes deprecation of `serializationIgnoreIn`:
```
../../.dub/packages/influx-d-0.4.1/influx-d/source/influxdb/api.d(1008,12): Deprecation: alias asdf.serialization.serializationIgnoreIn is deprecated - use @serdeIgnoreIn instead
../../.dub/packages/influx-d-0.4.1/influx-d/source/influxdb/api.d(1008,12): Deprecation: alias asdf.serialization.serializationIgnoreIn is deprecated - use @serdeIgnoreIn instead
```